### PR TITLE
Fix compiler -Wreturn-type warning.

### DIFF
--- a/src/color-grid.cpp
+++ b/src/color-grid.cpp
@@ -52,6 +52,8 @@ ColorGrid::ColorGrid(const FracGrid& frac_grid, ColorFunc gradient, Pattern patt
                 return pinwheel_transforms;
             case Pattern::fiducial:
                 return fiducial_transforms;
+            default:
+                return vector<Transform>();
         }
     }();
 


### PR DESCRIPTION
When building with g++, the compiler shows a warning about control reaching the end of a non-void function.
This PR removes the warning by adding the default branch to the switch statement.