### PR TITLE
Fix sha256_initial_hash_value linker error

### DIFF
--- a/src/bit-aggregator.cpp
+++ b/src/bit-aggregator.cpp
@@ -1,5 +1,8 @@
 #include "bit-aggregator.hpp"
 
+namespace LifeHash
+{
+
 void BitAggregator::append(bool bit) {
     if (bitMask == 0) {
         bitMask = 0x80;
@@ -16,3 +19,5 @@ void BitAggregator::append(bool bit) {
 Data BitAggregator::data() const {
     return _data;
 }
+
+} // namespace LifeHash

--- a/src/bit-aggregator.hpp
+++ b/src/bit-aggregator.hpp
@@ -5,6 +5,9 @@
 
 #include "data.hpp"
 
+namespace LifeHash
+{
+
 // A class that accumulates bits fed into it and returns a block of data containing those bits.
 class BitAggregator {
    private:
@@ -15,5 +18,7 @@ class BitAggregator {
     void append(bool bit);
     Data data() const;
 };
+
+} // namespace LifeHash
 
 #endif

--- a/src/bit-enumerator.cpp
+++ b/src/bit-enumerator.cpp
@@ -2,6 +2,9 @@
 
 #include <stdexcept>
 
+namespace LifeHash
+{
+
 BitEnumerator::BitEnumerator(const Data& data) : data(data) {}
 
 bool BitEnumerator::has_next() const { return mask != 0 || index != data.size() - 1; }
@@ -60,3 +63,5 @@ int BitEnumerator::next_uint16() {
 }
 
 double BitEnumerator::next_frac() { return next_uint16() / 65535.0; }
+
+} // namespace LifeHash

--- a/src/bit-enumerator.hpp
+++ b/src/bit-enumerator.hpp
@@ -7,6 +7,9 @@
 
 #include "data.hpp"
 
+namespace LifeHash
+{
+
 // A class that takes a block of data and returns its bits singularly or in clusters.
 struct BitEnumerator {
    private:
@@ -31,4 +34,5 @@ struct BitEnumerator {
     }
 };
 
+} //namespace LifeHash
 #endif

--- a/src/cell-grid.cpp
+++ b/src/cell-grid.cpp
@@ -3,6 +3,9 @@
 #include "bit-aggregator.hpp"
 #include <assert.h>
 
+namespace LifeHash
+{
+
 CellGrid::CellGrid(const Size& size)  : Grid(size) {}
 
 Data CellGrid::data() const {
@@ -23,3 +26,5 @@ void CellGrid::set_data(const Data& data) {
     });
     assert(i == storage.end());
 }
+
+} // namespace LifeHash

--- a/src/cell-grid.hpp
+++ b/src/cell-grid.hpp
@@ -5,6 +5,9 @@
 #include "data.hpp"
 #include "grid.hpp"
 
+namespace LifeHash
+{
+
 // A class that holds an array of boolean cells and that is
 // capable of running Conway's Game of Life to produce the
 // next generation.
@@ -60,5 +63,7 @@ class CellGrid : public Grid<bool> {
 
     virtual Color color_for_value(const bool& value) const { return value ? Color::white : Color::black; }
 };
+
+} // namespace LifeHash
 
 #endif

--- a/src/change-grid.hpp
+++ b/src/change-grid.hpp
@@ -3,6 +3,9 @@
 
 #include "grid.hpp"
 
+namespace LifeHash
+{
+
 // A grid used to optimize the running of Conway's Game of Life by keeping
 // track of cells that need consideration in the next generation, which
 // allows the pruning of cells that don't need consideration.
@@ -18,5 +21,7 @@ class ChangeGrid : public Grid<bool> {
 
     virtual Color color_for_value(const bool& value) const { return value ? Color::red : Color::blue; }
 };
+
+} // namespace LifeHash
 
 #endif

--- a/src/color-func.cpp
+++ b/src/color-func.cpp
@@ -1,6 +1,9 @@
 #include "color-func.hpp"
 #include "numeric.hpp"
 
+namespace LifeHash
+{
+
 ColorFunc reverse(ColorFunc c) {
     return [=](double t) { return c(1 - t); };
 }
@@ -40,3 +43,5 @@ ColorFunc blend(const std::vector<Color>& colors) {
             break;
     }
 }
+
+} // namespace LifeHash

--- a/src/color-func.hpp
+++ b/src/color-func.hpp
@@ -5,6 +5,9 @@
 #include <functional>
 #include <vector>
 
+namespace LifeHash
+{
+
 // A function that takes a fraction [0..1] and returns a color along a gradient.
 typedef std::function<Color(double)> ColorFunc;
 
@@ -16,5 +19,7 @@ ColorFunc blend(const Color& color1, const Color& color2);
 
 // Returns a color function that blends through each of the given colors at equal intervals.
 ColorFunc blend(const std::vector<Color>& colors);
+
+} // namespace LifeHash
 
 #endif

--- a/src/color-grid.cpp
+++ b/src/color-grid.cpp
@@ -2,6 +2,9 @@
 
 #include <algorithm>
 
+namespace LifeHash
+{
+
 using namespace std;
 
 Size ColorGrid::target_size(const Size& in_size, Pattern pattern) {
@@ -67,3 +70,5 @@ void ColorGrid::draw(const Point& p, const Color& color, const vector<Transform>
         set_value(color, p2);
     }
 }
+
+} // namespace LifeHash

--- a/src/color-grid.hpp
+++ b/src/color-grid.hpp
@@ -7,6 +7,9 @@
 #include "frac-grid.hpp"
 #include "patterns.hpp"
 
+namespace LifeHash
+{
+
 // A class that takes a grayscale grid and applies color and
 // symmetery to it to yield the finished LifeHash.
 class ColorGrid : public Grid<Color> {
@@ -31,5 +34,7 @@ class ColorGrid : public Grid<Color> {
     static std::vector<Transform> pinwheel_transforms;
     static std::vector<Transform> fiducial_transforms;
 };
+
+} // namespace LifeHash
 
 #endif

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -4,6 +4,9 @@
 
 #include "hsb-color.hpp"
 
+namespace LifeHash
+{
+
 Color::Color(const HSBColor &hsbColor) {
     Color c = hsbColor.color();
     this->r = c.r;
@@ -42,3 +45,5 @@ Color Color::lerp_to(const Color &other, double t) const {
 Color Color::from_uint8_values(uint8_t r, uint8_t g, uint8_t b) {
     return Color(double(r) / 255, double(g) / 255, double(b) / 255);
 }
+
+} // namespace LifeHash

--- a/src/color.hpp
+++ b/src/color.hpp
@@ -3,6 +3,9 @@
 
 #include "numeric.hpp"
 
+namespace LifeHash
+{
+
 struct HSBColor;
 
 // A struct representing a color.
@@ -35,5 +38,7 @@ struct Color {
 
     double luminance() const;
 };
+
+} // namespace LifeHash
 
 #endif

--- a/src/data.hpp
+++ b/src/data.hpp
@@ -5,7 +5,12 @@
 
 #include <vector>
 
+namespace LifeHash
+{
+
 // An idiom for a block of data used throughout LifeHash.
 typedef std::vector<uint8_t> Data;
+
+} // namespace LifeHash
 
 #endif

--- a/src/format-utils.cpp
+++ b/src/format-utils.cpp
@@ -4,6 +4,9 @@
 
 using namespace std;
 
+namespace LifeHash
+{
+
 const string to_hex(const Data& data) {
     auto hex = "0123456789abcdef";
     string result;
@@ -22,3 +25,5 @@ const string to_binary(const Data& data) {
     e.for_all([&](bool b) { result.push_back(b ? '1' : '0'); });
     return result;
 }
+
+} // namespace LifeHash

--- a/src/format-utils.hpp
+++ b/src/format-utils.hpp
@@ -5,6 +5,9 @@
 
 #include "data.hpp"
 
+namespace LifeHash
+{
+
 // Convert the given data to a hex string.
 const std::string to_hex(const Data& data);
 
@@ -13,5 +16,7 @@ const Data to_data(const std::string& utf8);
 
 // Covert the given block of data to a string of 1s and 0s.
 const std::string to_binary(const Data& data);
+
+} // namespace LifeHash
 
 #endif

--- a/src/frac-grid.hpp
+++ b/src/frac-grid.hpp
@@ -3,6 +3,9 @@
 
 #include "cell-grid.hpp"
 
+namespace LifeHash
+{
+
 // A grid of floating point values in [0..1], used for onion-skinning
 // the generations of the Game of Life into a single grayscale image.
 class FracGrid : public Grid<double> {
@@ -19,5 +22,7 @@ class FracGrid : public Grid<double> {
 
     virtual Color color_for_value(const double& value) const { return Color::black.lerp_to(Color::white, value); }
 };
+
+} // namespace LifeHash
 
 #endif

--- a/src/gradients.cpp
+++ b/src/gradients.cpp
@@ -5,8 +5,10 @@
 #include "color.hpp"
 #include "hsb-color.hpp"
 
-using namespace LifeHash;
 using namespace std;
+
+namespace LifeHash
+{
 
 static ColorFunc grayscale = blend(Color::black, Color::white);
 
@@ -330,3 +332,5 @@ ColorFunc select_gradient(BitEnumerator& entropy, Version version) {
     }
     return grayscale;
 }
+
+} // namespace LifeHash

--- a/src/gradients.hpp
+++ b/src/gradients.hpp
@@ -5,8 +5,13 @@
 #include "bit-enumerator.hpp"
 #include "color-func.hpp"
 
+namespace LifeHash
+{
+
 // A function that takes a deterministic source of bits and selects a gradient
 // used to color a particular LifeHash version.
 ColorFunc select_gradient(BitEnumerator& entropy, LifeHash::Version version);
+
+} // namespace LifeHash
 
 #endif

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -9,6 +9,9 @@
 #include "point.hpp"
 #include "size.hpp"
 
+namespace LifeHash
+{
+
 // A class that holds a 2-dimensional grid of values, 
 // and allows the reading, writing, and iteration 
 // through those values.
@@ -75,5 +78,7 @@ class Grid {
         return result;
     }
 };
+
+} // namespace LifeHash
 
 #endif

--- a/src/hsb-color.cpp
+++ b/src/hsb-color.cpp
@@ -7,6 +7,9 @@
 #include "color.hpp"
 #include "numeric.hpp"
 
+namespace LifeHash
+{
+
 HSBColor::HSBColor(const Color &color) {
     auto r = color.r;
     auto g = color.g;
@@ -99,3 +102,5 @@ Color HSBColor::color() const {
 
     return Color(red, green, blue);
 }
+
+} // namespace LifeHash

--- a/src/hsb-color.hpp
+++ b/src/hsb-color.hpp
@@ -1,6 +1,9 @@
 #ifndef LIFEHASH_HSB_COLOR_HPP
 #define LIFEHASH_HSB_COLOR_HPP
 
+namespace LifeHash
+{
+
 struct Color;
 
 // A struct representing a color in the HSB space.
@@ -16,5 +19,7 @@ struct HSBColor {
 
     Color color() const;
 };
+
+} // namespace LifeHash
 
 #endif

--- a/src/memzero.cpp
+++ b/src/memzero.cpp
@@ -48,6 +48,9 @@
 // Adapted from
 // https://github.com/jedisct1/libsodium/blob/1647f0d53ae0e370378a9195477e3df0a792408f/src/libsodium/sodium/utils.c#L102-L130
 
+namespace LifeHash
+{
+
 void memzero(void *const pnt, const size_t len) {
 #ifdef _WIN32
   SecureZeroMemory(pnt, len);
@@ -82,3 +85,5 @@ void memzero(void *const pnt, const size_t len) {
   __asm__ __volatile__("" : : "r"(pnt_) : "memory");
 #endif
 }
+
+} // namespace LifeHash

--- a/src/memzero.hpp
+++ b/src/memzero.hpp
@@ -3,7 +3,12 @@
 
 #include <stddef.h>
 
+namespace LifeHash
+{
+
 // Memory-zeroing utility used by the SHA256 algorithm.
 void memzero(void* const pnt, const size_t len);
+
+} // namespace LifeHash
 
 #endif

--- a/src/numeric.hpp
+++ b/src/numeric.hpp
@@ -4,6 +4,9 @@
 #include <math.h>
 #include "stdint.h"
 
+namespace LifeHash
+{
+
 // Interpolate `t` from [0..1] to [a..b].
 inline double lerp_to(double toA, double toB, double t) { return t * (toB - toA) + toA; }
 
@@ -31,5 +34,7 @@ inline double clamped(double n) { return max(min(n, 1), 0); }
 // Return `dividend` MODULO `divisor` where `dividend` can be negative,
 // but the result is always non-negative.
 inline double modulo(double dividend, double divisor) { return fmodf(fmodf(dividend, divisor) + divisor, divisor); }
+
+} // namespace LifeHash
 
 #endif

--- a/src/patterns.cpp
+++ b/src/patterns.cpp
@@ -1,6 +1,7 @@
 #include "patterns.hpp"
 
-using namespace LifeHash;
+namespace LifeHash
+{
 
 Pattern select_pattern(BitEnumerator& entropy, Version version) {
     switch(version) {
@@ -11,3 +12,5 @@ Pattern select_pattern(BitEnumerator& entropy, Version version) {
             return entropy.next() ? Pattern::snowflake : Pattern::pinwheel;
     }
 }
+
+} // namespace LifeHash

--- a/src/patterns.hpp
+++ b/src/patterns.hpp
@@ -4,6 +4,9 @@
 #include "version.hpp"
 #include "bit-enumerator.hpp"
 
+namespace LifeHash
+{
+
 // The symmetries used by LifeHash
 enum class Pattern {
     snowflake, // Mirror around central axes.
@@ -14,5 +17,7 @@ enum class Pattern {
 // A function that takes a deterministic source of bits and selects a pattern
 // used to add symmetry to a a particular LifeHash version.
 Pattern select_pattern(BitEnumerator& entropy, LifeHash::Version version);
+
+} // namespace LifeHash
 
 #endif

--- a/src/point.cpp
+++ b/src/point.cpp
@@ -1,3 +1,8 @@
 #include "point.hpp"
 
+namespace LifeHash
+{
+
 const Point Point::zero = Point(0, 0);
+
+} // namespace LifeHash

--- a/src/point.hpp
+++ b/src/point.hpp
@@ -1,6 +1,9 @@
 #ifndef LIFEHASH_POINT_HPP
 #define LIFEHASH_POINT_HPP
 
+namespace LifeHash
+{
+
 // A struct representing an integer cartesian point.
 struct Point {
     int x;
@@ -12,5 +15,7 @@ struct Point {
 };
 
 inline bool operator==(const Point& lhs, const Point& rhs) { return lhs.x == rhs.x && lhs.y == rhs.y; }
+
+} // namespace LifeHash
 
 #endif

--- a/src/sha256.cpp
+++ b/src/sha256.cpp
@@ -35,6 +35,9 @@
 
 #include "memzero.hpp"
 
+namespace LifeHash
+{
+
 /*** SHA-256/384/512 Machine Architecture Definitions *****************/
 /*
  * BYTE_ORDER NOTE:
@@ -365,3 +368,5 @@ const Data sha256(const Data& buf) {
     sha256_Raw(buf.data(), buf.size(), digest);
     return Data(digest, digest + SHA256_DIGEST_LENGTH);
 }
+
+} // namespace LifeHash

--- a/src/sha256.hpp
+++ b/src/sha256.hpp
@@ -36,6 +36,9 @@
 
 #include "data.hpp"
 
+namespace LifeHash
+{
+
 #define SHA256_BLOCK_LENGTH 64
 #define SHA256_DIGEST_LENGTH 32
 #define SHA256_DIGEST_STRING_LENGTH (SHA256_DIGEST_LENGTH * 2 + 1)
@@ -77,5 +80,7 @@ char* sha256_Data(const uint8_t*, size_t, char[SHA256_DIGEST_STRING_LENGTH]);
 
 // Calculates the SHA256 digest of the given data.
 const Data sha256(const Data& buf);
+
+} // namespace LifeHash
 
 #endif

--- a/src/size.hpp
+++ b/src/size.hpp
@@ -3,6 +3,9 @@
 
 #include <cstddef>
 
+namespace LifeHash
+{
+
 // A struct representing an integer 2-dimensional size.
 struct Size {
     int width;
@@ -10,5 +13,7 @@ struct Size {
 
     Size(int width, int height) : width(width), height(height) {}
 };
+
+} // namespace LifeHash
 
 #endif


### PR DESCRIPTION
When linked together with libbc-ur, the linker ends with a "multiple definitions of sha256_initial_hash_value" error.
This PR fixes the problem by placing all project data into the LifeHash namespace.